### PR TITLE
beaglebone-black-g-ether-load: make sure udhcpd is installed

### DIFF
--- a/scripts/beaglebone-black-g-ether-load.sh
+++ b/scripts/beaglebone-black-g-ether-load.sh
@@ -3,6 +3,9 @@
 #Based off:
 #https://github.com/beagleboard/meta-beagleboard/blob/master/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
 
+#Make sure udhcpd is installed
+type udhcpd >/dev/null 2>&1 ||  apt-get install udhcpd 
+
 SERIAL_NUMBER="0C-1234BBBK5678"
 ISBLACK=""
 PRODUCT="am335x_evm"

--- a/scripts/beaglebone-black-g-ether-load.sh
+++ b/scripts/beaglebone-black-g-ether-load.sh
@@ -3,8 +3,9 @@
 #Based off:
 #https://github.com/beagleboard/meta-beagleboard/blob/master/meta-beagleboard-extras/recipes-support/usb-gadget/gadget-init/g-ether-load.sh
 
-#Make sure udhcpd is installed
+#Make sure udhcpd and dnsmasq is installed
 type udhcpd >/dev/null 2>&1 ||  apt-get install udhcpd 
+type dnsmasq >/dev/null 2>&1 ||  apt-get install dnsmasq 
 
 SERIAL_NUMBER="0C-1234BBBK5678"
 ISBLACK=""


### PR DESCRIPTION
I noticed that the udhcpd is not installed in Kali Linux.
So I add a script to make sure udhcpd is installed
